### PR TITLE
feat(pkg): support oneOf responses

### DIFF
--- a/pkg/builder/intermediate_representation.go
+++ b/pkg/builder/intermediate_representation.go
@@ -26,6 +26,11 @@ type TypeDeclaration struct {
 	Schema    *openapi3.Schema
 }
 
+type OneOfDeclaration struct {
+	Name    string
+	Options []string
+}
+
 // StructField holds the information for StructField of a type.
 type StructField struct {
 	// Name of the field

--- a/pkg/builder/types.go
+++ b/pkg/builder/types.go
@@ -35,6 +35,24 @@ func (tt *TypeDeclaration) String() string {
 	return buf.String()
 }
 
+func (o *OneOfDeclaration) String() string {
+	buf := new(strings.Builder)
+	fmt.Fprintf(buf, "type %s struct {\n", o.Name)
+	for _, opt := range o.Options {
+		fmt.Fprintf(buf, "\t%s *%s\n", opt, opt)
+	}
+	fmt.Fprintf(buf, "}\n\n")
+	for _, opt := range o.Options {
+		fmt.Fprintf(buf, "func (r *%s) As%s() (*%s, bool) {\n", o.Name, opt, opt)
+		fmt.Fprintf(buf, "\tif r.%s != nil {\n", opt)
+		fmt.Fprintf(buf, "\t\treturn r.%s, true\n", opt)
+		fmt.Fprint(buf, "\t}\n\n")
+		fmt.Fprint(buf, "\t\treturn nil, false\n")
+		fmt.Fprint(buf, "\t}\n\n")
+	}
+	return buf.String()
+}
+
 func (f *StructField) String() string {
 	buf := new(strings.Builder)
 	if f.Comment != "" {

--- a/templates/tag.go.tmpl
+++ b/templates/tag.go.tmpl
@@ -34,7 +34,7 @@ type {{.Service}} service
 {{- with .Description}}
 // {{.}}
 {{- end }}
-func (s *{{$.Service}}) {{.FunctionName}}({{.ParamsString}}) {{with .ResponseType}}(*{{.}}, error){{else}}error{{end}} {
+func (s *{{$.Service}}) {{.FunctionName}}({{.ParamsString}}) {{with .ResponseType}}(*{{.Type}}, error){{else}}error{{end}} {
 	{{with .HasBody -}}
     buf := new(bytes.Buffer)
     if err := json.NewEncoder(buf).Encode(body); err != nil {
@@ -86,7 +86,13 @@ func (s *{{$.Service}}) {{.FunctionName}}({{.ParamsString}}) {{with .ResponseTyp
 			return nil, fmt.Errorf("decode response: %s", err.Error())
 		}
 
+		{{ if $responseType.IsOneOf }}
+		return &{{ $responseType.Type }}{
+			{{.}}: &v,
+		}, nil
+		{{- else }}
 		return &v, nil
+		{{- end }}
 		{{- else}}
 		return {{with $responseType}}nil, {{end}}nil
 	    {{- end}}


### PR DESCRIPTION
If an operation returns multiple successful responses of different
types, generate a helper oneOf type that can be casted to one of the
options.
