### PR TITLE
Improve testability: Change APIUrl from const to var

### DIFF
--- a/templates/client.go.tmpl
+++ b/templates/client.go.tmpl
@@ -16,7 +16,9 @@ import (
 
 const (
 	version = "0.0.1" // x-release-please-version
+)
 
+var (
 	// APIUrl is the URL of our API.
 	APIUrl = "https://api.sumup.com"
 )


### PR DESCRIPTION
I am currently trying to write test cases that allow us to evaluate how our service reacts to different responses from Sumup. As part of this, I was looking for a way to use the sumup-go library for these tests.

The idea is to use the `httptest` library and create an `httptest.Server` that simulates the requests from Sumup. This would allow a test to look something like this:

```golang
import (
	// ...
	"github.com/sumup/sumup-go/client"
	"github.com/sumup/sumup-go"
	// ...
)

func TestSumUp(t *testing.T) {
    	server := httptest.NewServer(
		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
			// Simulate responses ...
		}),
	)

	client.APIUrl = server.URL

	c := sumup.NewClient()

	// ...
}
```

In order for this to work, the constant APIUrl would need to become configurable so that it can be set to the value of the test server.

Thank you very much for taking the time to review and work on this PR — I appreciate your feedback and input!